### PR TITLE
[FIX] 헤더 상단 플로팅

### DIFF
--- a/src/app/(main)/layout.module.scss
+++ b/src/app/(main)/layout.module.scss
@@ -1,4 +1,5 @@
 .layout {
+  min-width: 360px;
   display: flex;
   flex-direction: column;
   height: 100dvh;

--- a/src/app/(main)/layout.module.scss
+++ b/src/app/(main)/layout.module.scss
@@ -1,7 +1,7 @@
 .layout {
   display: flex;
   flex-direction: column;
-  height: 100vh;
+  height: 100dvh;
   overflow: hidden;
 }
 

--- a/src/app/(main)/layout.module.scss
+++ b/src/app/(main)/layout.module.scss
@@ -1,0 +1,12 @@
+.layout {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  overflow: hidden;
+}
+
+.main {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--spacing-24);
+}

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -1,17 +1,19 @@
 import { Header, NavItem } from "@/widgets/ui/Header";
 
+import styles from "./layout.module.scss";
+
 const MainLayout = ({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) => {
   return (
-    <div>
+    <div className={styles.layout}>
       <Header title="PLANIT" userName="PLANIT">
         <NavItem href="/dashboard">대시보드</NavItem>
         <NavItem href="/attendance">출결관리</NavItem>
       </Header>
-      <main>{children}</main>
+      <main className={styles.main}>{children}</main>
     </div>
   );
 };

--- a/src/widgets/ui/Header/Header.module.scss
+++ b/src/widgets/ui/Header/Header.module.scss
@@ -1,11 +1,9 @@
 .header {
   width: 100%;
   height: 64px;
+  flex-shrink: 0;
   background-color: var(--background);
   box-shadow: var(--shadow-embossed);
-  margin-bottom: var(--spacing-5);
-  position: sticky;
-  top: 0;
   z-index: 100;
 }
 

--- a/src/widgets/ui/Header/Header.module.scss
+++ b/src/widgets/ui/Header/Header.module.scss
@@ -8,7 +8,6 @@
 }
 
 .container {
-  max-width: 1440px;
   height: 100%;
   margin: 0 auto;
   padding: 0 var(--spacing-24);
@@ -36,12 +35,16 @@
   font-size: var(--font-size-xl);
   font-weight: var(--font-weight-semibold);
   color: var(--foreground);
+
+  @media (max-width: 400px) {
+    display: none;
+  }
 }
 
 .nav {
   display: flex;
   align-items: center;
-  gap: var(--spacing-32);
+  gap: var(--spacing-16);
 }
 
 .navList {
@@ -52,7 +55,7 @@
 }
 
 .navLink {
-  padding: var(--spacing-8) var(--spacing-16);
+  padding: var(--spacing-8) var(--spacing-8);
   font-family: var(--font-family);
   font-size: var(--font-size-base);
   font-weight: var(--font-weight-semibold);

--- a/src/widgets/ui/Header/Header.tsx
+++ b/src/widgets/ui/Header/Header.tsx
@@ -18,7 +18,7 @@ const Header = ({ title, userName, children }: HeaderProps) => {
       <div className={styles.container}>
         <Link href="/" className={styles.logo}>
           <div className={styles.logoIcon}>
-            <Image alt="logo" src="logo.svg" width={40} height={40} />
+            <Image alt="logo" src="logo.svg" width={40} height={40} priority />
           </div>
           <span className={styles.logoText}>{title}</span>
         </Link>


### PR DESCRIPTION
## Key Changes

<!--- 바뀐 부분을 간략하게 작성해주세요 -->

- 헤더와 컨텐츠 영역 분리를 통해 스크롤이 컨텐츠 영역에만 생김
- 헤더를 상단 플로팅 시켜서 항상 상단에 위치하게 함

## 작업 내역

<!--- 변경 사항 및 관련 이슈에 대해 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
<!--- 연관된 이슈를 작성해주세요 #(Issue Number) -->

- 헤더와 컨텐츠 영역 분리를 통해 스크롤이 컨텐츠 영역에만 생김
- 헤더를 상단 플로팅 시켜서 항상 상단에 위치하게 함
- close #16 

## 📸 스크린샷
<img width="558" height="286" alt="image" src="https://github.com/user-attachments/assets/61d60099-5ad1-4693-a74c-122dc0c4cb1b" />


## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] Eslint 및 Prettier 규칙을 준수했습니다.
- [x] origin/develop 브랜치에서의 최신 커밋을 확인하고 반영했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **스타일**
  * 앱 전체 레이아웃에 세로 방향의 플렉스 구조와 전체 화면 높이 적용, 메인 영역에 스크롤 및 내부 여백이 추가되었습니다.
  * 헤더의 고정(sticky) 위치 지정이 제거되고 축소 동작(flex-shrink)이 적용되어 레이아웃 흐름이 개선되었습니다.
  * 헤더 관련 하단 여백이 제거되어 UI 간 간격이 조정되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->