### PR TITLE
[FEAT] 차트 카드 컴포넌트 추가

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,9 +1,6 @@
 {
   "customSyntax": "postcss-scss",
-  "extends": [
-    "stylelint-config-standard-scss",
-    "stylelint-config-prettier-scss"
-  ],
+  "extends": ["stylelint-config-standard-scss"],
   "rules": {
     "selector-class-pattern": "^[a-z][a-zA-Z0-9]+$",
     "scss/no-global-function-names": null,

--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
     "prettier": "^3.7.4",
     "storybook": "^10.1.4",
     "stylelint": "^16.26.1",
-    "stylelint-config-prettier-scss": "^1.0.0",
     "stylelint-config-recommended-scss": "^16.0.2",
     "stylelint-config-standard": "^39.0.1",
     "stylelint-config-standard-scss": "^16.0.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "react": "19.2.1",
     "react-dom": "19.2.1",
     "react-redux": "^9.2.0",
+    "recharts": "^3.5.1",
     "sass": "^1.94.2"
   },
   "devDependencies": {
@@ -78,7 +79,6 @@
     "prettier": "^3.7.4",
     "storybook": "^10.1.4",
     "stylelint": "^16.26.1",
-    "stylelint-config-prettier": "^9.0.5",
     "stylelint-config-prettier-scss": "^1.0.0",
     "stylelint-config-recommended-scss": "^16.0.2",
     "stylelint-config-standard": "^39.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,9 +147,6 @@ importers:
       stylelint:
         specifier: ^16.26.1
         version: 16.26.1(typescript@5.9.3)
-      stylelint-config-prettier-scss:
-        specifier: ^1.0.0
-        version: 1.0.0(stylelint@16.26.1(typescript@5.9.3))
       stylelint-config-recommended-scss:
         specifier: ^16.0.2
         version: 16.0.2(postcss@8.5.6)(stylelint@16.26.1(typescript@5.9.3))
@@ -3684,13 +3681,6 @@ packages:
         optional: true
       babel-plugin-macros:
         optional: true
-
-  stylelint-config-prettier-scss@1.0.0:
-    resolution: {integrity: sha512-Gr2qLiyvJGKeDk0E/+awNTrZB/UtNVPLqCDOr07na/sLekZwm26Br6yYIeBYz3ulsEcQgs5j+2IIMXCC+wsaQA==}
-    engines: {node: 14.* || 16.* || >= 18}
-    hasBin: true
-    peerDependencies:
-      stylelint: '>=15.0.0'
 
   stylelint-config-recommended-scss@16.0.2:
     resolution: {integrity: sha512-aUTHhPPWCvFyWaxtckJlCPaXTDFsp4pKO8evXNCsW9OwsaUWyMd6jvcUhSmfGWPrTddvzNqK4rS/UuSLcbVGdQ==}
@@ -7763,10 +7753,6 @@ snapshots:
       react: 19.2.1
     optionalDependencies:
       '@babel/core': 7.28.5
-
-  stylelint-config-prettier-scss@1.0.0(stylelint@16.26.1(typescript@5.9.3)):
-    dependencies:
-      stylelint: 16.26.1(typescript@5.9.3)
 
   stylelint-config-recommended-scss@16.0.2(postcss@8.5.6)(stylelint@16.26.1(typescript@5.9.3)):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       react-redux:
         specifier: ^9.2.0
         version: 9.2.0(@types/react@19.2.7)(react@19.2.1)(redux@5.0.1)
+      recharts:
+        specifier: ^3.5.1
+        version: 3.5.1(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react-is@17.0.2)(react@19.2.1)(redux@5.0.1)
       sass:
         specifier: ^1.94.2
         version: 1.94.2
@@ -144,9 +147,6 @@ importers:
       stylelint:
         specifier: ^16.26.1
         version: 16.26.1(typescript@5.9.3)
-      stylelint-config-prettier:
-        specifier: ^9.0.5
-        version: 9.0.5(stylelint@16.26.1(typescript@5.9.3))
       stylelint-config-prettier-scss:
         specifier: ^1.0.0
         version: 1.0.0(stylelint@16.26.1(typescript@5.9.3))
@@ -1379,6 +1379,33 @@ packages:
   '@types/conventional-commits-parser@5.0.2':
     resolution: {integrity: sha512-BgT2szDXnVypgpNxOK8aL5SGjUdaQbC++WZNjF1Qge3Og2+zhHj+RWhmehLhYyvQwqAmvezruVfOf8+3m74W+g==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-shape@3.1.7':
+    resolution: {integrity: sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
@@ -1877,6 +1904,10 @@ packages:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
 
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -1960,6 +1991,50 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.0:
+    resolution: {integrity: sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
 
@@ -1995,6 +2070,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js-light@2.5.1:
+    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
 
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
@@ -2118,6 +2196,9 @@ packages:
   es-to-primitive@1.3.0:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
+
+  es-toolkit@1.42.0:
+    resolution: {integrity: sha512-SLHIyY7VfDJBM8clz4+T2oquwTQxEzu263AyhVK4jREOAwJ+8eebaa4wM3nlvnAqhDrMm2EsA6hWHaQsMPQ1nA==}
 
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
@@ -2593,6 +2674,9 @@ packages:
     engines: {node: '>=16.x'}
     hasBin: true
 
+  immer@10.2.0:
+    resolution: {integrity: sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==}
+
   immer@11.0.1:
     resolution: {integrity: sha512-naDCyggtcBWANtIrjQEajhhBEuL9b0Zg4zmlWK2CzS6xCWSE39/vvf4LqnMjUAWHBhot4m9MHCM/Z+mfWhUkiA==}
 
@@ -2624,6 +2708,10 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
@@ -3309,6 +3397,14 @@ packages:
     resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
     engines: {node: '>= 4'}
 
+  recharts@3.5.1:
+    resolution: {integrity: sha512-+v+HJojK7gnEgG6h+b2u7k8HH7FhyFUzAc4+cPrsjL4Otdgqr/ecXzAnHciqlzV1ko064eNcsdzrYOM78kankA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-is: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
@@ -3596,13 +3692,6 @@ packages:
     peerDependencies:
       stylelint: '>=15.0.0'
 
-  stylelint-config-prettier@9.0.5:
-    resolution: {integrity: sha512-U44lELgLZhbAD/xy/vncZ2Pq8sh2TnpiPvo38Ifg9+zeioR+LAkHu0i6YORIOxFafZoVg0xqQwex6e6F25S5XA==}
-    engines: {node: '>= 12'}
-    hasBin: true
-    peerDependencies:
-      stylelint: '>= 11.x < 15'
-
   stylelint-config-recommended-scss@16.0.2:
     resolution: {integrity: sha512-aUTHhPPWCvFyWaxtckJlCPaXTDFsp4pKO8evXNCsW9OwsaUWyMd6jvcUhSmfGWPrTddvzNqK4rS/UuSLcbVGdQ==}
     engines: {node: '>=20'}
@@ -3810,6 +3899,9 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  victory-vendor@37.3.6:
+    resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
 
   vite-plugin-storybook-nextjs@3.1.2:
     resolution: {integrity: sha512-MvjMMr3qM/c7GOYGqYGljV9Fidm2607w6XYRAWDQeQEqcX3Xe77H8oKhLSV46RGEd6JVztGY8lVLgel+K3iA3Q==}
@@ -5058,6 +5150,30 @@ snapshots:
     dependencies:
       '@types/node': 20.19.25
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-shape@3.1.7':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/doctrine@0.0.9': {}
@@ -5620,6 +5736,8 @@ snapshots:
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
 
+  clsx@2.1.1: {}
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -5695,6 +5813,44 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-color@3.1.0: {}
+
+  d3-ease@3.0.1: {}
+
+  d3-format@3.1.0: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.0
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
   damerau-levenshtein@1.0.8: {}
 
   dargs@8.1.0: {}
@@ -5724,6 +5880,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js-light@2.5.1: {}
 
   deep-eql@5.0.2: {}
 
@@ -5899,6 +6057,8 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  es-toolkit@1.42.0: {}
 
   esbuild@0.25.12:
     optionalDependencies:
@@ -6523,6 +6683,8 @@ snapshots:
 
   image-size@2.0.2: {}
 
+  immer@10.2.0: {}
+
   immer@11.0.1: {}
 
   immutable@5.1.4: {}
@@ -6547,6 +6709,8 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.1.0
+
+  internmap@2.0.3: {}
 
   is-array-buffer@3.0.5:
     dependencies:
@@ -7199,6 +7363,26 @@ snapshots:
       tiny-invariant: 1.3.3
       tslib: 2.8.1
 
+  recharts@3.5.1(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react-is@17.0.2)(react@19.2.1)(redux@5.0.1):
+    dependencies:
+      '@reduxjs/toolkit': 2.11.0(react-redux@9.2.0(@types/react@19.2.7)(react@19.2.1)(redux@5.0.1))(react@19.2.1)
+      clsx: 2.1.1
+      decimal.js-light: 2.5.1
+      es-toolkit: 1.42.0
+      eventemitter3: 5.0.1
+      immer: 10.2.0
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+      react-is: 17.0.2
+      react-redux: 9.2.0(@types/react@19.2.7)(react@19.2.1)(redux@5.0.1)
+      reselect: 5.1.1
+      tiny-invariant: 1.3.3
+      use-sync-external-store: 1.6.0(react@19.2.1)
+      victory-vendor: 37.3.6
+    transitivePeerDependencies:
+      - '@types/react'
+      - redux
+
   redent@3.0.0:
     dependencies:
       indent-string: 4.0.0
@@ -7584,10 +7768,6 @@ snapshots:
     dependencies:
       stylelint: 16.26.1(typescript@5.9.3)
 
-  stylelint-config-prettier@9.0.5(stylelint@16.26.1(typescript@5.9.3)):
-    dependencies:
-      stylelint: 16.26.1(typescript@5.9.3)
-
   stylelint-config-recommended-scss@16.0.2(postcss@8.5.6)(stylelint@16.26.1(typescript@5.9.3)):
     dependencies:
       postcss-scss: 4.0.9(postcss@8.5.6)
@@ -7857,6 +8037,23 @@ snapshots:
       react: 19.2.1
 
   util-deprecate@1.0.2: {}
+
+  victory-vendor@37.3.6:
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-ease': 3.0.2
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-shape': 3.1.7
+      '@types/d3-time': 3.0.4
+      '@types/d3-timer': 3.0.2
+      d3-array: 3.2.4
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-timer: 3.0.1
 
   vite-plugin-storybook-nextjs@3.1.2(next@16.0.7(@babel/core@7.28.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.94.2))(storybook@10.1.4(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(typescript@5.9.3)(vite@7.2.6(@types/node@20.19.25)(jiti@2.6.1)(sass@1.94.2)(yaml@2.8.2)):
     dependencies:

--- a/src/app/(main)/dashboard/page.tsx
+++ b/src/app/(main)/dashboard/page.tsx
@@ -1,0 +1,3 @@
+import { Dashboard } from "@/page-layer/dashboard";
+
+export default Dashboard;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -113,6 +113,7 @@
   --foreground-error: var(--color-system-error);
   --foreground-notice: var(--color-system-notice);
   --foreground-like: var(--color-system-like);
+  --foreground-disable: var(--color-grey-normal);
 
   /* Border */
   --border-normal: var(--color-grey-light-intense);

--- a/src/page-layer/dashboard/index.ts
+++ b/src/page-layer/dashboard/index.ts
@@ -1,0 +1,1 @@
+export { default as Dashboard } from "./page";

--- a/src/page-layer/dashboard/page.tsx
+++ b/src/page-layer/dashboard/page.tsx
@@ -1,0 +1,13 @@
+import { DoughnutChartCard } from "@/widgets/ui/DoughnutChartCard";
+
+const data = [
+  { label: "총 출석", value: 12, color: "var(--foreground-success)" },
+  { label: "총 결석", value: 19, color: "var(--foreground-error)" },
+  { label: "미출결", value: 3, color: "var(--foreground-disable)" },
+];
+
+const Dashboard = () => {
+  return <DoughnutChartCard title="출석률" data={data} />;
+};
+
+export default Dashboard;

--- a/src/shared/ui/Card/Card.tsx
+++ b/src/shared/ui/Card/Card.tsx
@@ -8,6 +8,7 @@ interface CardProps {
   titleIcon?: React.ReactNode;
   children: React.ReactNode;
   width?: string;
+  onClick?: () => void;
 }
 
 const Card = ({
@@ -16,9 +17,14 @@ const Card = ({
   titleIcon,
   children,
   width = "100%",
+  onClick,
 }: CardProps) => {
   return (
-    <div className={`${styles.card} ${styles[variant]}`} style={{ width }}>
+    <div
+      className={`${styles.card} ${styles[variant]}`}
+      style={{ width }}
+      onClick={onClick}
+    >
       {title && (
         <div className={styles.header}>
           {titleIcon && <span className={styles.titleIcon}>{titleIcon}</span>}

--- a/src/shared/ui/Card/Card.tsx
+++ b/src/shared/ui/Card/Card.tsx
@@ -8,7 +8,7 @@ interface CardProps {
   titleIcon?: React.ReactNode;
   children: React.ReactNode;
   width?: string;
-  onClick?: () => void;
+  isClickable?: boolean;
 }
 
 const Card = ({
@@ -17,14 +17,12 @@ const Card = ({
   titleIcon,
   children,
   width = "100%",
-  onClick,
+  isClickable = false,
 }: CardProps) => {
+  const Wrapper = isClickable ? "button" : "div";
+
   return (
-    <div
-      className={`${styles.card} ${styles[variant]}`}
-      style={{ width }}
-      onClick={onClick}
-    >
+    <Wrapper className={`${styles.card} ${styles[variant]}`} style={{ width }}>
       {title && (
         <div className={styles.header}>
           {titleIcon && <span className={styles.titleIcon}>{titleIcon}</span>}
@@ -32,7 +30,7 @@ const Card = ({
         </div>
       )}
       <div className={styles.content}>{children}</div>
-    </div>
+    </Wrapper>
   );
 };
 

--- a/src/shared/ui/Chart/DoughnutChart.tsx
+++ b/src/shared/ui/Chart/DoughnutChart.tsx
@@ -1,0 +1,54 @@
+import { PieChart, Pie, Cell, ResponsiveContainer } from "recharts";
+
+export interface ChartItem {
+  label: string;
+  value: number;
+  color: string;
+}
+
+function convertToPieData(items: ChartItem[]) {
+  return items.map((item) => ({
+    name: item.label,
+    value: item.value,
+    fill: item.color,
+  }));
+}
+
+interface DoughnutChartProps {
+  data: ChartItem[];
+  width?: string | number;
+}
+
+const DoughnutChart = ({ data, width = "100%" }: DoughnutChartProps) => {
+  const pieData = convertToPieData(data);
+
+  return (
+    <div
+      style={{
+        width,
+        pointerEvents: "none",
+      }}
+    >
+      <ResponsiveContainer width="100%" aspect={1}>
+        <PieChart>
+          <Pie
+            data={pieData}
+            cx="50%"
+            cy="50%"
+            innerRadius="70%"
+            outerRadius="100%"
+            paddingAngle={2}
+            dataKey="value"
+            nameKey="name"
+          >
+            {pieData.map((entry, index) => (
+              <Cell key={`cell-${index}`} fill={entry.fill} />
+            ))}
+          </Pie>
+        </PieChart>
+      </ResponsiveContainer>
+    </div>
+  );
+};
+
+export default DoughnutChart;

--- a/src/shared/ui/Chart/index.ts
+++ b/src/shared/ui/Chart/index.ts
@@ -1,0 +1,1 @@
+export { default as DoughnutChart } from "./DoughnutChart";

--- a/src/widgets/ui/DoughnutChartCard/DoughnutChartCard.module.scss
+++ b/src/widgets/ui/DoughnutChartCard/DoughnutChartCard.module.scss
@@ -52,3 +52,10 @@
   min-width: 50px;
   padding: var(--spacing-8);
 }
+
+.noDataBox {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}

--- a/src/widgets/ui/DoughnutChartCard/DoughnutChartCard.module.scss
+++ b/src/widgets/ui/DoughnutChartCard/DoughnutChartCard.module.scss
@@ -1,0 +1,54 @@
+.cardContainer {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  height: 100%;
+}
+
+.legend {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-4);
+  width: auto;
+  justify-content: center;
+  align-items: start;
+  margin-left: auto;
+}
+
+.legendItem {
+  display: flex;
+  width: auto;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-8);
+}
+
+.colorDot {
+  width: 12px;
+  height: 12px;
+  border-radius: var(--radius-full);
+}
+
+.label {
+  font-size: var(--font-size-md);
+}
+
+.value {
+  color: var(--foreground);
+  font-size: var(--font-size-md);
+}
+
+.percent {
+  color: var(--foreground-disable);
+  font-size: var(--font-size-md);
+}
+
+.chartBox {
+  flex: 1 1 auto;
+  max-width: 200px;
+  min-width: 50px;
+  padding: var(--spacing-8);
+}

--- a/src/widgets/ui/DoughnutChartCard/DoughnutChartCard.tsx
+++ b/src/widgets/ui/DoughnutChartCard/DoughnutChartCard.tsx
@@ -14,20 +14,21 @@ interface DoughnutChartCardProps {
 }
 
 const DoughnutChartCard = ({ title, data }: DoughnutChartCardProps) => {
+  const total = data.reduce((sum, item) => sum + item.value, 0);
+
+  const showChart = data.length > 0 && total !== 0;
+
   const legendData = useMemo(() => {
-    const total = data.reduce((sum, item) => sum + item.value, 0);
     return data.map((item) => ({
       ...item,
-      percent: ((item.value / total) * 100).toFixed(1),
+      percent: total === 0 ? "0.0" : ((item.value / total) * 100).toFixed(1),
     }));
-  }, [data]);
-
-  const hasData = data.length > 0;
+  }, [data, total]);
 
   return (
     <Card title={title}>
       <div className={styles.cardContainer}>
-        {!hasData ? (
+        {!showChart ? (
           <div className={styles.noDataBox}>
             <span>데이터가 없습니다</span>
           </div>

--- a/src/widgets/ui/DoughnutChartCard/DoughnutChartCard.tsx
+++ b/src/widgets/ui/DoughnutChartCard/DoughnutChartCard.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useMemo } from "react";
+
+import { Card } from "@/shared/ui/Card";
+import { DoughnutChart } from "@/shared/ui/Chart";
+import type { ChartItem } from "@/shared/ui/Chart/DoughnutChart";
+
+import styles from "./DoughnutChartCard.module.scss";
+
+interface DoughnutChartCardProps {
+  title: string;
+  data: ChartItem[];
+}
+
+const DoughnutChartCard = ({ title, data }: DoughnutChartCardProps) => {
+  const total = data.reduce((sum, item) => sum + item.value, 0);
+
+  const legendData = useMemo(() => {
+    return data.map((item) => ({
+      ...item,
+      percent: ((item.value / total) * 100).toFixed(1),
+    }));
+  }, [data, total]);
+
+  return (
+    <Card title={title}>
+      <div className={styles.cardContainer}>
+        <div className={styles.chartBox}>
+          <DoughnutChart data={data} />
+        </div>
+
+        <div className={styles.legend}>
+          {legendData.map((item) => (
+            <div key={item.label} className={styles.legendItem}>
+              <span
+                className={styles.colorDot}
+                style={{ backgroundColor: item.color }}
+              />
+              <span className={styles.label}>{item.label}</span>
+              <span className={styles.value}>{item.value}</span>
+              <span className={styles.percent}>({item.percent}%)</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </Card>
+  );
+};
+
+export default DoughnutChartCard;

--- a/src/widgets/ui/DoughnutChartCard/DoughnutChartCard.tsx
+++ b/src/widgets/ui/DoughnutChartCard/DoughnutChartCard.tsx
@@ -14,35 +14,43 @@ interface DoughnutChartCardProps {
 }
 
 const DoughnutChartCard = ({ title, data }: DoughnutChartCardProps) => {
-  const total = data.reduce((sum, item) => sum + item.value, 0);
-
   const legendData = useMemo(() => {
+    const total = data.reduce((sum, item) => sum + item.value, 0);
     return data.map((item) => ({
       ...item,
       percent: ((item.value / total) * 100).toFixed(1),
     }));
-  }, [data, total]);
+  }, [data]);
+
+  const hasData = data.length > 0;
 
   return (
     <Card title={title}>
       <div className={styles.cardContainer}>
-        <div className={styles.chartBox}>
-          <DoughnutChart data={data} />
-        </div>
-
-        <div className={styles.legend}>
-          {legendData.map((item) => (
-            <div key={item.label} className={styles.legendItem}>
-              <span
-                className={styles.colorDot}
-                style={{ backgroundColor: item.color }}
-              />
-              <span className={styles.label}>{item.label}</span>
-              <span className={styles.value}>{item.value}</span>
-              <span className={styles.percent}>({item.percent}%)</span>
+        {!hasData ? (
+          <div className={styles.noDataBox}>
+            <span>데이터가 없습니다</span>
+          </div>
+        ) : (
+          <>
+            <div className={styles.chartBox}>
+              <DoughnutChart data={data} />
             </div>
-          ))}
-        </div>
+            <div className={styles.legend}>
+              {legendData.map((item) => (
+                <div key={item.label} className={styles.legendItem}>
+                  <span
+                    className={styles.colorDot}
+                    style={{ backgroundColor: item.color }}
+                  />
+                  <span className={styles.label}>{item.label}</span>
+                  <span className={styles.value}>{item.value}</span>
+                  <span className={styles.percent}>({item.percent}%)</span>
+                </div>
+              ))}
+            </div>
+          </>
+        )}
       </div>
     </Card>
   );

--- a/src/widgets/ui/DoughnutChartCard/index.ts
+++ b/src/widgets/ui/DoughnutChartCard/index.ts
@@ -1,0 +1,1 @@
+export { default as DoughnutChartCard } from "./DoughnutChartCard";


### PR DESCRIPTION
## Key Changes

<!--- 바뀐 부분을 간략하게 작성해주세요 -->

- 차트 컴포넌트 추가
- 차트 카드 텀포넌트 구현

## 작업 내역

<!--- 변경 사항 및 관련 이슈에 대해 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
<!--- 연관된 이슈를 작성해주세요 #(Issue Number) -->

- recharts 라이브러리 사용해서 도넛 차트 컴포넌트 구현
- 차트 카드 텀포넌트 구현
- 대시포드 페이지에서 import
- close: #40

## 📸 스크린샷
<img width="460" height="306" alt="image" src="https://github.com/user-attachments/assets/ee6e3bcc-bc83-415d-affb-47f4aa9be93b" />

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] Eslint 및 Prettier 규칙을 준수했습니다.
- [x] origin/develop 브랜치에서의 최신 커밋을 확인하고 반영했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 대시보드 페이지 추가 — 출석률을 도넛 차트로 시각화하여 확인 가능.
  * 도넛 차트 컴포넌트 및 도넛 차트 카드 위젯 추가 — 범례, 퍼센트 표시 및 데이터 없음(데이터가 없습니다) 상태 지원.
  * 카드 컴포넌트에 클릭 가능 옵션 추가(isClickable).

* **스타일**
  * 도넛 차트 카드용 CSS 모듈 및 전역 CSS에 비활성 전경(--foreground-disable) 변수 추가.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->