### PR TITLE
[FIX]: 온보딩페이지 기존유저와 신규유저 차별화

### DIFF
--- a/src/app/bootcamps/page.tsx
+++ b/src/app/bootcamps/page.tsx
@@ -1,3 +1,11 @@
+import { Suspense } from "react";
+
 import { Onboarding } from "@/page-layer/onboarding";
 
-export default Onboarding;
+export default function Page() {
+  return (
+    <Suspense fallback={null}>
+      <Onboarding />
+    </Suspense>
+  );
+}

--- a/src/page-layer/mypage/ui/MyBootcampListCard/MyBootcampListCard.tsx
+++ b/src/page-layer/mypage/ui/MyBootcampListCard/MyBootcampListCard.tsx
@@ -23,9 +23,10 @@ const MyBootcampListCard = ({ bootcamps }: MyBootcampListCardProps) => {
   const [isModalOpen, setModalOpen] = useState(false);
   const [selectBootcampId, setSelectBootcampId] = useState<number | null>(null);
   const router = useRouter();
+  const userType = "existing";
 
   const handleRegist = () => {
-    router.push("/bootcamps");
+    router.push(`/bootcamps?userType=${userType}`);
   };
 
   const handleDelete = () => {

--- a/src/page-layer/onboarding/Onboarding.module.scss
+++ b/src/page-layer/onboarding/Onboarding.module.scss
@@ -58,4 +58,5 @@
   display: flex;
   justify-content: flex-end;
   padding-top: 20px;
+  gap: var(--spacing-6);
 }

--- a/src/page-layer/onboarding/page.tsx
+++ b/src/page-layer/onboarding/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 import Image from "next/image";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useState } from "react";
 
 import { Bootcamp, BootcampList } from "@/feature/bootcamp";
@@ -12,9 +13,15 @@ const Onboarding = () => {
   const [selectedBootcamp, setSelectedBootcamp] = useState<Bootcamp | null>(
     null,
   );
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const userType = searchParams.get("userType");
 
   const handleRegister = () => {
     console.log("부트캠프 등록", selectedBootcamp);
+  };
+  const handleCancel = () => {
+    router.back();
   };
 
   return (
@@ -38,6 +45,11 @@ const Onboarding = () => {
             />
           </div>
           <div className={styles.footer}>
+            {userType === "existing" && (
+              <Button onClick={handleCancel} variant="outline" width="100px">
+                취소
+              </Button>
+            )}
             <Button
               disabled={!selectedBootcamp}
               variant="primary"


### PR DESCRIPTION
## Key Changes

- 온보딩 페이지를 신규유저와 기존유저간 차별화 주었습니다.

## 작업 내역

- 쿼리스트링으로 온보딩페이지에 취소버튼 볼수있게 제작
- close #72 

## 📸 스크린샷
<img width="932" height="848" alt="image" src="https://github.com/user-attachments/assets/05d4d518-5537-4967-ae8e-181f69988e57" />
<img width="930" height="849" alt="image" src="https://github.com/user-attachments/assets/79d11f63-1222-4f40-a883-e9a5716511e0" />

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] Eslint 및 Prettier 규칙을 준수했습니다.
- [ ] origin/develop 브랜치에서의 최신 커밋을 확인하고 반영했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리즈 노트

* **새로운 기능**
  * 온보딩에서 기존 사용자일 때 표시되는 취소 버튼이 추가되었습니다.
  * 부트캠프 등록 버튼 클릭 시 사용자 유형(기존 사용자)이 유지되어 등록 흐름으로 이동합니다.

* **스타일**
  * 온보딩 푸터의 가로 간격이 개선되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->