### PR TITLE
[FIX] userId 전역 상태 참조

### DIFF
--- a/src/feature/attendance/hooks/useAttendanceData.ts
+++ b/src/feature/attendance/hooks/useAttendanceData.ts
@@ -12,11 +12,8 @@ import {
 } from "@/feature/attendance/api";
 import { useMyBootcamps } from "@/feature/enrollment/api";
 import { useSessionsWithAttendance } from "@/feature/session/api";
+import { useAppSelector } from "@/shared/store/hooks";
 import type { DateData } from "@/shared/ui/Calendar";
-
-interface UseAttendanceDataOptions {
-  userId: number;
-}
 
 interface UseAttendanceDataReturn {
   bootcampOptions: BootcampOption[];
@@ -36,9 +33,8 @@ interface UseAttendanceDataReturn {
 
 export const useAttendanceData = (
   selectedBootcampIndex: number,
-  options: UseAttendanceDataOptions,
 ): UseAttendanceDataReturn => {
-  const { userId } = options;
+  const userId = useAppSelector((state) => state.auth.userId);
 
   const {
     data: bootcampSummaryData,

--- a/src/feature/attendance/hooks/useAttendanceData.ts
+++ b/src/feature/attendance/hooks/useAttendanceData.ts
@@ -16,6 +16,7 @@ import { useAppSelector } from "@/shared/store/hooks";
 import type { DateData } from "@/shared/ui/Calendar";
 
 interface UseAttendanceDataReturn {
+  userId: number | null;
   bootcampOptions: BootcampOption[];
   selectedBootcampId: number | null;
   allCalendarDates: DateData[];
@@ -85,6 +86,7 @@ export const useAttendanceData = (
   const selectedBootcamp = bootcampOptions[selectedBootcampIndex];
 
   return {
+    userId,
     bootcampOptions,
     selectedBootcampId,
     allCalendarDates,

--- a/src/feature/auth/model/useGoogleLogin.ts
+++ b/src/feature/auth/model/useGoogleLogin.ts
@@ -7,6 +7,7 @@ import { useDispatch } from "react-redux";
 import { MeResponse } from "@/feature/user";
 import { apiClient, ApiResponse } from "@/shared/api";
 import { auth } from "@/shared/config/firebaseConfig";
+import { setAuth } from "@/shared/store/authSlice";
 import { showToast } from "@/shared/store/toastSlice";
 
 import { login } from "../api/login";
@@ -35,6 +36,12 @@ export const useGoogleLogin = () => {
     },
 
     onSuccess: (me) => {
+      dispatch(
+        setAuth({
+          userId: me.id,
+          recentBootcampId: me.recentBootcampId,
+        }),
+      );
       router.replace(me.recentBootcampId == null ? "/bootcamps" : "/dashboard");
     },
 

--- a/src/page-layer/attendance/page.tsx
+++ b/src/page-layer/attendance/page.tsx
@@ -20,7 +20,6 @@ import {
 import { AttendanceSummaryCardSkeleton } from "@/entities/attendance/ui/AttendanceSummaryCard";
 import { BootcampInfo } from "@/entities/bootcamp/ui/BootcampInfo";
 import { useToast } from "@/shared/lib";
-import { useAppSelector } from "@/shared/store/hooks";
 import { Card } from "@/shared/ui";
 import { Toggle } from "@/shared/ui";
 import type { ToggleOption } from "@/shared/ui";
@@ -108,7 +107,6 @@ const UNIT_COLORS_CONFIG = {
 } as const;
 
 const Attendance = () => {
-  const userId = useAppSelector((state) => state.auth.userId);
   const toast = useToast();
 
   const [selectedBootcampIndex, setSelectedBootcampIndex] = useState(0);
@@ -131,6 +129,7 @@ const Attendance = () => {
   );
 
   const {
+    userId,
     bootcampOptions,
     selectedBootcampId,
     allCalendarDates,

--- a/src/page-layer/attendance/page.tsx
+++ b/src/page-layer/attendance/page.tsx
@@ -20,6 +20,7 @@ import {
 import { AttendanceSummaryCardSkeleton } from "@/entities/attendance/ui/AttendanceSummaryCard";
 import { BootcampInfo } from "@/entities/bootcamp/ui/BootcampInfo";
 import { useToast } from "@/shared/lib";
+import { useAppSelector } from "@/shared/store/hooks";
 import { Card } from "@/shared/ui";
 import { Toggle } from "@/shared/ui";
 import type { ToggleOption } from "@/shared/ui";
@@ -107,8 +108,7 @@ const UNIT_COLORS_CONFIG = {
 } as const;
 
 const Attendance = () => {
-  // TODO: 인증에서 userId 가져오기
-  const userId = 1;
+  const userId = useAppSelector((state) => state.auth.userId);
   const toast = useToast();
 
   const [selectedBootcampIndex, setSelectedBootcampIndex] = useState(0);
@@ -144,7 +144,7 @@ const Attendance = () => {
     errorSessions,
     updateAttendanceMutation,
     deleteAttendanceMutation,
-  } = useAttendanceData(selectedBootcampIndex, { userId });
+  } = useAttendanceData(selectedBootcampIndex);
 
   useAttendanceErrors({
     isErrorBootcamps,
@@ -246,6 +246,7 @@ const Attendance = () => {
   const handleSaveEdit = useCallback(
     async (dates: Date[], status: AttendanceStatus | undefined) => {
       if (selectedBootcampId == null) return;
+      if (userId == null) return;
 
       const classDates = formatDatesToStrings(dates);
 


### PR DESCRIPTION
## Key Changes

<!--- 바뀐 부분을 간략하게 작성해주세요 -->

- userId 상수로 정의 되어 있던 것을 전역 상태 참조로 변경

## 작업 내역

<!--- 변경 사항 및 관련 이슈에 대해 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
<!--- 연관된 이슈를 작성해주세요 #(Issue Number) -->

- userId 상수로 정의 되어 있던 것을 전역 상태 참조로 변경

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] Eslint 및 Prettier 규칙을 준수했습니다.
- [x] origin/develop 브랜치에서의 최신 커밋을 확인하고 반영했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 출석 데이터가 중앙 상태에서 직접 사용자 정보를 참조하도록 통합해 내부 흐름을 단순화했습니다.
* **버그 수정**
  * 저장 동작 시 사용자 식별자가 없으면 조기 종료하는 안전장치를 추가해 오류 가능성을 줄였습니다.
* **개선**
  * 구글 로그인 후 인증 정보(사용자 ID 및 최근 부트캠프)를 즉시 상태에 반영해 이후 흐름이 안정적으로 동작하도록 개선했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->