### PR TITLE
[FEAT] AuthHydrator 추가

### DIFF
--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { Header, NavItem } from "@/widgets/ui";
 
 import styles from "./layout.module.scss";

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -1,14 +1,8 @@
-import { checkAuth } from "@/feature/auth/server";
 import { Header, NavItem } from "@/widgets/ui";
 
 import styles from "./layout.module.scss";
 
-export default async function MainLayout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
-  await checkAuth();
+const MainLayout = ({ children }: { children: React.ReactNode }) => {
   return (
     <div className={styles.layout}>
       <Header title="PLANIT">
@@ -19,4 +13,6 @@ export default async function MainLayout({
       <main className={styles.main}>{children}</main>
     </div>
   );
-}
+};
+
+export default MainLayout;

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -11,7 +11,7 @@ export default async function MainLayout({
   await checkAuth();
   return (
     <div className={styles.layout}>
-      <Header title="PLANIT" userName="PLANIT">
+      <Header title="PLANIT">
         <NavItem href="/dashboard">대시보드</NavItem>
         <NavItem href="/attendance">출결관리</NavItem>
       </Header>

--- a/src/app/(sub)/layout.tsx
+++ b/src/app/(sub)/layout.tsx
@@ -1,16 +1,11 @@
-import { checkAuth } from "@/feature/auth/server";
-
+"use client";
 import styles from "./layout.module.scss";
-
-export default async function SubLayout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
-  await checkAuth();
+const SubLayout = ({ children }: { children: React.ReactNode }) => {
   return (
     <div className={styles.layout}>
       <main className={styles.main}>{children}</main>
     </div>
   );
-}
+};
+
+export default SubLayout;

--- a/src/app/(sub)/layout.tsx
+++ b/src/app/(sub)/layout.tsx
@@ -1,4 +1,3 @@
-"use client";
 import styles from "./layout.module.scss";
 const SubLayout = ({ children }: { children: React.ReactNode }) => {
   return (

--- a/src/feature/auth/model/useGoogleLogin.ts
+++ b/src/feature/auth/model/useGoogleLogin.ts
@@ -39,6 +39,7 @@ export const useGoogleLogin = () => {
       dispatch(
         setAuth({
           userId: me.id,
+          displayName: me.displayName,
           recentBootcampId: me.recentBootcampId,
         }),
       );

--- a/src/shared/providers/AuthHydrator.tsx
+++ b/src/shared/providers/AuthHydrator.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { useEffect } from "react";
+import { useDispatch } from "react-redux";
+
+import type { MeResponse } from "@/feature/user";
+import { apiClient, type ApiResponse } from "@/shared/api";
+import { clearAuth, setAuth } from "@/shared/store/authSlice";
+
+const AuthHydrator = () => {
+  const dispatch = useDispatch();
+  const pathname = usePathname();
+
+  useEffect(() => {
+    if (!pathname) return;
+    if (pathname.startsWith("/signin")) return;
+
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const meRes = await apiClient.get<ApiResponse<MeResponse>>("/users/me");
+        const me = meRes.data.data;
+        if (!me || cancelled) return;
+
+        dispatch(
+          setAuth({
+            userId: me.id,
+            recentBootcampId: me.recentBootcampId,
+          }),
+        );
+      } catch {
+        dispatch(clearAuth());
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [dispatch, pathname]);
+
+  return null;
+};
+
+export default AuthHydrator;

--- a/src/shared/providers/AuthHydrator.tsx
+++ b/src/shared/providers/AuthHydrator.tsx
@@ -27,6 +27,7 @@ const AuthHydrator = () => {
         dispatch(
           setAuth({
             userId: me.id,
+            displayName: me.displayName,
             recentBootcampId: me.recentBootcampId,
           }),
         );

--- a/src/shared/providers/AuthHydrator.tsx
+++ b/src/shared/providers/AuthHydrator.tsx
@@ -32,7 +32,9 @@ const AuthHydrator = () => {
           }),
         );
       } catch {
+        await apiClient.post("/auth/logout");
         dispatch(clearAuth());
+        window.location.href = "/signin";
       }
     })();
 

--- a/src/shared/providers/AuthHydrator.tsx
+++ b/src/shared/providers/AuthHydrator.tsx
@@ -4,14 +4,15 @@ import { usePathname } from "next/navigation";
 import { useEffect } from "react";
 import { useDispatch } from "react-redux";
 
+import { useLogout } from "@/feature/auth/api";
 import type { MeResponse } from "@/feature/user";
 import { apiClient, type ApiResponse } from "@/shared/api";
-import { clearAuth, setAuth } from "@/shared/store/authSlice";
+import { setAuth } from "@/shared/store/authSlice";
 
 const AuthHydrator = () => {
   const dispatch = useDispatch();
   const pathname = usePathname();
-
+  const { mutate: logout } = useLogout();
   useEffect(() => {
     if (!pathname) return;
     if (pathname.startsWith("/signin")) return;
@@ -32,16 +33,14 @@ const AuthHydrator = () => {
           }),
         );
       } catch {
-        await apiClient.post("/auth/logout");
-        dispatch(clearAuth());
-        window.location.href = "/signin";
+        logout();
       }
     })();
 
     return () => {
       cancelled = true;
     };
-  }, [dispatch, pathname]);
+  }, [dispatch, pathname, logout]);
 
   return null;
 };

--- a/src/shared/providers/index.tsx
+++ b/src/shared/providers/index.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import AuthHydrator from "./AuthHydrator";
 import QueryProvider from "./QueryProvider";
 import StoreProvider from "./StoreProvider";
 
@@ -10,7 +11,10 @@ interface ProvidersProps {
 const Providers = ({ children }: ProvidersProps) => {
   return (
     <StoreProvider>
-      <QueryProvider>{children}</QueryProvider>
+      <QueryProvider>
+        <AuthHydrator />
+        {children}
+      </QueryProvider>
     </StoreProvider>
   );
 };

--- a/src/shared/store/authSlice.ts
+++ b/src/shared/store/authSlice.ts
@@ -3,12 +3,14 @@ import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 type AuthState = {
   isAuthenticated: boolean;
   userId: number | null;
+  displayName: string | null;
   recentBootcampId: number | null;
 };
 
 const initialState: AuthState = {
   isAuthenticated: false,
   userId: null,
+  displayName: null,
   recentBootcampId: null,
 };
 
@@ -20,16 +22,19 @@ const authSlice = createSlice({
       state,
       action: PayloadAction<{
         userId: number;
+        displayName: string;
         recentBootcampId: number | null;
       }>,
     ) => {
       state.isAuthenticated = true;
       state.userId = action.payload.userId;
+      state.displayName = action.payload.displayName;
       state.recentBootcampId = action.payload.recentBootcampId;
     },
     clearAuth: (state) => {
       state.isAuthenticated = false;
       state.userId = null;
+      state.displayName = null;
       state.recentBootcampId = null;
     },
   },

--- a/src/widgets/ui/Header/Header.tsx
+++ b/src/widgets/ui/Header/Header.tsx
@@ -1,18 +1,23 @@
+"use client";
+
 import Image from "next/image";
 import Link from "next/link";
 import React from "react";
 
+import { useAppSelector } from "@/shared/store/hooks";
 import { Avatar } from "@/shared/ui";
 
 import styles from "./Header.module.scss";
 
 interface HeaderProps {
   title: string;
-  userName: string;
   children?: React.ReactNode;
 }
 
-const Header = ({ title, userName, children }: HeaderProps) => {
+const Header = ({ title, children }: HeaderProps) => {
+  const displayName = useAppSelector((state) => state.auth.displayName);
+  const userName = displayName ?? "PLANIT";
+
   return (
     <header className={styles.header}>
       <div className={styles.container}>


### PR DESCRIPTION
## Key Changes

<!--- 바뀐 부분을 간략하게 작성해주세요 -->

- 새로고침 후에도 서버 세션이 살아있으면 userId가 자동으로 복구

## 작업 내역

- 앱이 뜰 때 /users/me로 세션을 확인해서 스토어를 재수화하도록 추가

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] Eslint 및 Prettier 규칙을 준수했습니다.
- [x] origin/develop 브랜치에서의 최신 커밋을 확인하고 반영했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 앱 시작/라우트 이동 시 현재 사용자 정보를 자동으로 불러와 인증 상태를 초기화합니다.

* **개선 사항**
  * 인증 상태에 사용자 표시 이름(displayName)이 추가되어 UI에 정확한 이름이 반영됩니다.
  * 헤더가 외부에서 사용자 이름을 받지 않고 내부 상태에서 직접 가져와 아바타와 표시를 처리합니다.

* **리팩터**
  * 레이아웃 초기화 흐름이 클라이언트 중심으로 간소화되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->